### PR TITLE
fix: align Feishu streaming finalization with Hermes consumer

### DIFF
--- a/src/hermes_feishu_plugin/card/streaming.py
+++ b/src/hermes_feishu_plugin/card/streaming.py
@@ -333,7 +333,6 @@ async def _finalize_card(adapter: Any, chat_id: str, text: str, *, expected_gene
     if not message_id:
         return False
 
-    state.phase = "completed"
     if state.flush_controller:
         state.flush_controller.complete()
         await state.flush_controller.wait_for_flush()
@@ -358,6 +357,7 @@ async def _finalize_card(adapter: Any, chat_id: str, text: str, *, expected_gene
                 )
                 sequence = advance_card_sequence(adapter, chat_id)
                 await update_card(adapter, card_id=effective_card_id, card=to_cardkit2(complete_card), sequence=sequence)
+            state.phase = "completed"
             remember_display_text(adapter, chat_id, text)
             remember_last_flushed_text(adapter, chat_id, text)
             return True
@@ -367,9 +367,11 @@ async def _finalize_card(adapter: Any, chat_id: str, text: str, *, expected_gene
     async with get_card_update_lock(adapter, chat_id):
         response = await patch_interactive_card(adapter, message_id=message_id, card=complete_card)
     if response_ok(response):
+        state.phase = "completed"
         remember_display_text(adapter, chat_id, text)
         remember_last_flushed_text(adapter, chat_id, text)
         return True
+    logger.warning("hermes_feishu_plugin final IM patch fallback failed: message_id=%s", message_id)
     return False
 
 
@@ -379,7 +381,6 @@ async def abort_progress_card(adapter: Any, chat_id: str, reason: str | None = N
     if not state.card_message_id or state.phase in {"completed", "aborted", "terminated"}:
         return False
 
-    state.phase = "aborted"
     if state.flush_controller:
         state.flush_controller.complete()
         await state.flush_controller.wait_for_flush()
@@ -409,6 +410,7 @@ async def abort_progress_card(adapter: Any, chat_id: str, reason: str | None = N
                 )
                 sequence = advance_card_sequence(adapter, chat_id)
                 await update_card(adapter, card_id=effective_card_id, card=to_cardkit2(aborted_card), sequence=sequence)
+            state.phase = "aborted"
             remember_display_text(adapter, chat_id, text)
             remember_last_flushed_text(adapter, chat_id, text)
             return True
@@ -418,9 +420,11 @@ async def abort_progress_card(adapter: Any, chat_id: str, reason: str | None = N
     async with get_card_update_lock(adapter, chat_id):
         response = await patch_interactive_card(adapter, message_id=state.card_message_id, card=aborted_card)
     if response_ok(response):
+        state.phase = "aborted"
         remember_display_text(adapter, chat_id, text)
         remember_last_flushed_text(adapter, chat_id, text)
         return True
+    logger.warning("hermes_feishu_plugin abort IM patch fallback failed: message_id=%s", state.card_message_id)
     return False
 
 
@@ -444,20 +448,20 @@ def patch_streaming_cards() -> bool:
     if getattr(original_send_or_edit, "__hermes_feishu_plugin_wrapped__", False):
         return True
 
-    async def wrapped_send_or_edit(self: Any, text: str) -> None:
+    async def wrapped_send_or_edit(self: Any, text: str, *, finalize: bool = False) -> bool:
         cleaned = self._clean_for_display(text)
         if not cleaned.strip():
-            return
+            return True
 
         if not is_feishu_adapter(self.adapter):
-            return await original_send_or_edit(self, text)
+            return await original_send_or_edit(self, text, finalize=finalize)
         if not should_stream(self.adapter, self.chat_id):
-            return await original_send_or_edit(self, text)
+            return await original_send_or_edit(self, text, finalize=finalize)
 
         expected_generation = _resolve_expected_generation(self.adapter, self.chat_id, owner=self)
         if not _generation_matches(self.adapter, self.chat_id, expected_generation):
             self._already_sent = True
-            return
+            return False
 
         if should_suppress_status_message(cleaned):
             lines = parse_tool_progress_lines(cleaned)
@@ -470,12 +474,13 @@ def patch_streaming_cards() -> bool:
                     expected_generation=expected_generation,
                 )
             self._already_sent = True
-            return
+            return bool(lines)
 
-        if cleaned == self._last_sent_text:
-            return
+        if cleaned == self._last_sent_text and not finalize:
+            return True
 
-        visible_text, is_final = strip_cursor(cleaned, self.cfg.cursor)
+        visible_text, inferred_is_final = strip_cursor(cleaned, self.cfg.cursor)
+        is_final = bool(finalize or inferred_is_final)
         try:
             message_id = await _ensure_card_created(
                 self.adapter,
@@ -485,7 +490,7 @@ def patch_streaming_cards() -> bool:
                 expected_generation=expected_generation,
             )
             if not message_id:
-                return await original_send_or_edit(self, text)
+                return await original_send_or_edit(self, text, finalize=finalize)
 
             self._message_id = message_id
             remember_display_text(self.adapter, self.chat_id, visible_text)
@@ -496,7 +501,7 @@ def patch_streaming_cards() -> bool:
                     visible_text,
                     expected_generation=expected_generation,
                 ):
-                    return await original_send_or_edit(self, text)
+                    return await original_send_or_edit(self, text, finalize=finalize)
             else:
                 await _flush_answer(
                     self.adapter,
@@ -506,12 +511,13 @@ def patch_streaming_cards() -> bool:
 
             self._already_sent = True
             self._last_sent_text = cleaned
+            return True
         except Exception as exc:
             logger.warning("hermes_feishu_plugin CardKit streaming error: %s", exc)
             if not self._message_id:
-                await original_send_or_edit(self, text)
-            else:
-                self._already_sent = True
+                return await original_send_or_edit(self, text, finalize=finalize)
+            self._already_sent = True
+            return False
 
     wrapped_send_or_edit.__hermes_feishu_plugin_wrapped__ = True
     stream_consumer.GatewayStreamConsumer._send_or_edit = wrapped_send_or_edit

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
 from hermes_feishu_plugin.card import streaming
@@ -43,3 +46,106 @@ async def test_sync_progress_card_keeps_visible_text_when_tool_status_refreshes(
         if element.get("element_id") == streaming.STREAMING_ELEMENT_ID
     )
     assert content_element["content"] == "已输出的正文"
+
+
+@pytest.mark.asyncio
+async def test_finalize_card_keeps_streaming_phase_when_all_updates_fail(monkeypatch) -> None:
+    """Finalize failure should keep the card retryable instead of marking it completed."""
+    adapter = DummyAdapter()
+    state = get_chat_state(adapter, "chat-finalize-fail")
+    state.card_message_id = "om_card_1"
+    state.card_id = "card_1"
+    state.original_card_id = "card_1"
+    state.phase = "streaming"
+
+    async def fail_update_card(*_args, **_kwargs) -> None:
+        raise RuntimeError("cardkit update failed")
+
+    async def failed_patch_interactive_card(*_args, **_kwargs):
+        return SimpleNamespace(success=lambda: False)
+
+    monkeypatch.setattr(streaming, "set_card_streaming_mode", fail_update_card)
+    monkeypatch.setattr(streaming, "update_card", fail_update_card)
+    monkeypatch.setattr(streaming, "patch_interactive_card", failed_patch_interactive_card)
+
+    finalized = await streaming._finalize_card(adapter, "chat-finalize-fail", "最终回答")
+
+    assert finalized is False
+    assert state.phase == "streaming"
+
+
+@pytest.mark.asyncio
+async def test_abort_progress_card_keeps_streaming_phase_when_all_updates_fail(monkeypatch) -> None:
+    """Abort failure should keep the card retryable for the next inbound turn."""
+    adapter = DummyAdapter()
+    state = get_chat_state(adapter, "chat-abort-fail")
+    state.card_message_id = "om_card_2"
+    state.card_id = "card_2"
+    state.original_card_id = "card_2"
+    state.phase = "streaming"
+
+    async def fail_update_card(*_args, **_kwargs) -> None:
+        raise RuntimeError("cardkit update failed")
+
+    async def failed_patch_interactive_card(*_args, **_kwargs):
+        return SimpleNamespace(success=lambda: False)
+
+    monkeypatch.setattr(streaming, "set_card_streaming_mode", fail_update_card)
+    monkeypatch.setattr(streaming, "update_card", fail_update_card)
+    monkeypatch.setattr(streaming, "patch_interactive_card", failed_patch_interactive_card)
+
+    aborted = await streaming.abort_progress_card(adapter, "chat-abort-fail")
+
+    assert aborted is False
+    assert state.phase == "streaming"
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_run_finalizes_feishu_card_on_stream_end(monkeypatch) -> None:
+    """Feishu wrapper must accept finalize-aware stream-consumer calls and close the live card."""
+    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+    class FeishuAdapter:
+        name = "feishu"
+        MAX_MESSAGE_LENGTH = 4096
+
+    adapter = FeishuAdapter()
+    streaming.patch_streaming_cards()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-stream-end",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+    )
+    state = get_chat_state(adapter, "chat-stream-end")
+    state.card_message_id = "om_card_3"
+    state.phase = "streaming"
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(streaming, "should_stream", lambda *_args, **_kwargs: True)
+
+    async def fake_ensure_card_created(*_args, **_kwargs) -> str:
+        return "om_card_3"
+
+    async def fake_finalize_card(_adapter, chat_id: str, text: str, *, expected_generation: int = 0) -> bool:
+        captured["chat_id"] = chat_id
+        captured["text"] = text
+        captured["expected_generation"] = expected_generation
+        get_chat_state(_adapter, chat_id).phase = "completed"
+        return True
+
+    async def fake_flush_answer(*_args, **_kwargs) -> None:
+        captured["flushed"] = True
+
+    monkeypatch.setattr(streaming, "_ensure_card_created", fake_ensure_card_created)
+    monkeypatch.setattr(streaming, "_finalize_card", fake_finalize_card)
+    monkeypatch.setattr(streaming, "_flush_answer", fake_flush_answer)
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta("这是最终正文")
+    consumer.finish()
+    await task
+
+    assert captured["text"] == "这是最终正文"
+    assert consumer.final_response_sent is True
+    assert get_chat_state(adapter, "chat-stream-end").phase == "completed"


### PR DESCRIPTION
## Summary
- align the Feishu streaming wrapper with Hermes consumer finalize semantics
- only mark cards terminal after CardKit or IM fallback finalization succeeds
- add regression coverage for stream-end finalization and failed finalize/abort retries

## Testing
- /root/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_streaming.py
- HERMES_FEISHU_LOCALE=zh_cn /root/.hermes/hermes-agent/venv/bin/python -m pytest -q
